### PR TITLE
Waiting more than 0 seconds if the suggested time is zero

### DIFF
--- a/src/subtitle_tool/ai.py
+++ b/src/subtitle_tool/ai.py
@@ -250,7 +250,14 @@ class AISubtitler:
                 if detail.get("@type") == "type.googleapis.com/google.rpc.RetryInfo":
                     retry_delay = detail.get("retryDelay", "")
                     if retry_delay.endswith("s"):
-                        return float(retry_delay[:-1])
+                        delay = float(retry_delay[:-1])
+                        if delay == 0:
+                            logger.warning(
+                                f"Delay returned is zero, waiting the default {DEFAULT_WAIT_TIME} instead"  # noqa: E501
+                            )
+                            return DEFAULT_WAIT_TIME
+                        else:
+                            return delay
         except Exception as e:
             logger.warning(f"Could not parse retry delay from exception: {e}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "subtitle-tool"
-version = "0.1.22"
+version = "0.1.26"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
Gemini 2.5 Flash Lite is returning some zero waiting times with frequency. This change adds a default delay if the suggested time is 0 to avoid too many requests to the API.