### PR TITLE
Slightly raise the model temperature in case of generation errors

### DIFF
--- a/src/subtitle_tool/ai.py
+++ b/src/subtitle_tool/ai.py
@@ -481,7 +481,7 @@ class AISubtitler:
         ):
             with attempt:
                 subtitle_events = self._generate_subtitles(file_ref, temp_adj)
-                temp_adj += self.temperature_adj # To use in next call (if any)
+                temp_adj += self.temperature_adj  # To use in next call (if any)
                 validate_subtitles(subtitle_events, audio_segment.duration_seconds)
                 logger.debug("Valid subtitles generated for segment")
 

--- a/src/subtitle_tool/ai.py
+++ b/src/subtitle_tool/ai.py
@@ -27,7 +27,7 @@ from tenacity import (
 
 from subtitle_tool.subtitles import (
     SubtitleEvent,
-    SubtitleValidationException,
+    SubtitleValidationError,
     validate_subtitles,
 )
 from subtitle_tool.utils import sanitize_int
@@ -121,6 +121,9 @@ class AISubtitler:
         api_key (str): Gemini API key (mandatory)
         delete_temp_files (bool): whether any temporary files created
             should be deleted (default: True)
+        temperature (float): model temperature
+        temperature_adj (float): by how much the model temperature will be
+            adjusted for retries after incorrect content generation.
         system_prompt (str): system prompt driving the model. There is
             a default prompt already provided, override only if necessary.
     """
@@ -128,6 +131,8 @@ class AISubtitler:
     model_name: str
     api_key: str
     delete_temp_files: bool = True
+    temperature: float = 0.1
+    temperature_adj: float = 0.01
     system_prompt: str = """
         You are a professional transcriber of audio clips into subtitles.
         You recognize which language is being spoken in the title and write the subtitle accordingly.
@@ -357,7 +362,7 @@ class AISubtitler:
         # unneeded retries for problems we don't know about.
         should_ret = False
 
-        if isinstance(exception, SubtitleValidationException):
+        if isinstance(exception, SubtitleValidationError):
             logger.debug(f"Invalid subtitles generated: {exception}")
             self.metrics.add_metrics(invalid_subtitles=1)
             should_ret = True
@@ -468,19 +473,23 @@ class AISubtitler:
 
         subtitle_events = []
 
+        temp_adj = 0.0
         for attempt in Retrying(
             retry=retry_if_exception(self._subtitles_retry_handler),
             stop=stop_after_attempt(20),
             before_sleep=before_sleep_log(logger, logging.DEBUG),
         ):
             with attempt:
-                subtitle_events = self._generate_subtitles(file_ref)
+                subtitle_events = self._generate_subtitles(file_ref, temp_adj)
+                temp_adj += self.temperature_adj # To use in next call (if any)
                 validate_subtitles(subtitle_events, audio_segment.duration_seconds)
                 logger.debug("Valid subtitles generated for segment")
 
         return subtitle_events
 
-    def _generate_subtitles(self, file_ref) -> list[SubtitleEvent]:
+    def _generate_subtitles(
+        self, file_ref, temp_adj: float = 0.0
+    ) -> list[SubtitleEvent]:
         """
         Generate subtitles for the file uploaded onto Gemini servers.
 
@@ -498,6 +507,8 @@ class AISubtitler:
 
         Args:
             file_id (str): identifier of uploaded file
+            temp_adj (float): adjustment to configured temperature. Used to
+                increase the model temperature during new generations.
 
         Returns:
             list[SubtitleEvent]: subtitles extracted from audio track
@@ -514,8 +525,11 @@ class AISubtitler:
         ):
             with attempt:
                 response = None
+                temp = self.temperature + temp_adj
                 try:
-                    logger.debug("Asking Gemini to generate subtitles...")
+                    logger.debug(
+                        f"Asking Gemini to generate subtitles (temp: {temp})..."
+                    )
                     safety_settings = [
                         SafetySetting(
                             category=HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
@@ -542,7 +556,7 @@ class AISubtitler:
                             # Don't want to censor any subtitles
                             safety_settings=safety_settings,
                             system_instruction=self.system_prompt,
-                            temperature=0.1,
+                            temperature=temp,
                             http_options=HttpOptions(
                                 timeout=2 * 60 * 1000
                             ),  # 2 minutes

--- a/src/subtitle_tool/subtitles.py
+++ b/src/subtitle_tool/subtitles.py
@@ -22,7 +22,7 @@ class SubtitleEvent(BaseModel):
     model_config = ConfigDict(title="Individual subtitle text")
 
 
-class SubtitleValidationException(Exception):
+class SubtitleValidationError(Exception):
     pass
 
 
@@ -95,7 +95,7 @@ def validate_subtitles(subtitles: list[SubtitleEvent], duration: float):
         return
 
     if subtitles[-1].end > (duration * 1000):
-        raise SubtitleValidationException(
+        raise SubtitleValidationError(
             f"Subtitle ends at {subtitles[-1].end} "
             + f"({precisedelta(int(subtitles[-1].end / 1000))}) "
             + f" while audio segment ends at {duration * 1000} "
@@ -105,7 +105,7 @@ def validate_subtitles(subtitles: list[SubtitleEvent], duration: float):
     prev_end = 0
     for index, event in enumerate(subtitles):
         if event.start > event.end:
-            raise SubtitleValidationException(
+            raise SubtitleValidationError(
                 f"Subtitle {index} starts at {event.start} "
                 + f"({precisedelta(int(event.start / 1000))}) "
                 + f"but ends at {event.end} ({precisedelta(int(event.end / 1000))})"
@@ -116,7 +116,7 @@ def validate_subtitles(subtitles: list[SubtitleEvent], duration: float):
             continue
 
         if event.start < prev_end:
-            raise SubtitleValidationException(
+            raise SubtitleValidationError(
                 f"Subtitle {index} starts at {event.start} "
                 + f"(({precisedelta(int(event.start / 1000))})) "
                 + f"but the previous subtitle finishes at {prev_end} "

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -6,13 +6,14 @@ from unittest.mock import MagicMock, Mock, patch
 from google.genai.errors import ClientError, ServerError
 from pydub import AudioSegment
 from tenacity import RetryCallState
+import tenacity
 
 from subtitle_tool.ai import (
     DEFAULT_WAIT_TIME,
     AIGenerationError,
     AISubtitler,
 )
-from subtitle_tool.subtitles import SubtitleEvent
+from subtitle_tool.subtitles import SubtitleEvent, SubtitleValidationError
 
 # Running tests in DEBUG will help to troubleshoot errors on changes
 logging.getLogger("subtitle_tool").setLevel(logging.DEBUG)
@@ -640,6 +641,58 @@ class TestAISubtitler(unittest.TestCase):
 
         result = self.subtitler.transcribe_audio(self.mock_audio_segment)
         self.assertEqual(len(result), 2)
+
+    @patch("tempfile.NamedTemporaryFile")
+    def test_transcribe_audio_validation_error(self, mock_temp_file):
+        """Test successful audio transcription"""
+        # Setup mocks needed for the method to operate
+        mock_temp_file_instance = MagicMock()
+        mock_temp_file_instance.name = "/tmp/test_audio.wav"
+        mock_temp_file.return_value.__enter__.return_value = mock_temp_file_instance
+        mock_temp_file.return_value.__exit__.return_value = None
+
+        mock_client = Mock()
+        self.subtitler.client = mock_client
+
+        mock_ref = Mock()
+        mock_ref.name = "files/test_upload_id"
+        mock_client.files.upload.return_value = mock_ref
+
+        mock_response_usage_metadata = Mock()
+        mock_response_usage_metadata.cache_tokens_details = "Internal object"
+        mock_response_usage_metadata.cached_content_token_count = 0
+        mock_response_usage_metadata.prompt_token_count = 0
+        mock_response_usage_metadata.thoughts_token_count = 0
+        mock_response_usage_metadata.candidates_token_count = 0
+
+        mock_response = Mock()
+        mock_response.usage_metadata = mock_response_usage_metadata
+        # Invalid subtitle
+        mock_response.parsed = [
+            SubtitleEvent(start=1000, end=500, text="First"),
+            SubtitleEvent(start=5000, end=4000, text="Second"),
+        ]
+
+        mock_client.models.generate_content.return_value = mock_response
+
+        with patch("time.sleep", lambda _: None):
+            with self.assertRaises(tenacity.RetryError):
+                self.subtitler.transcribe_audio(self.mock_audio_segment)
+
+        # The transcribe audio function retries up to 20 times until
+        # it gives up. The first time, however, is done without any
+        # increase because we didn't see a validation error yet.
+        target_value = self.subtitler.temperature + 19 * self.subtitler.temperature_adj
+
+        _, kwargs = mock_client.models.generate_content.call_args
+        config = kwargs["config"]
+        temp = config.temperature
+        # Checking if the final temperature had increased
+        self.assertGreater(temp, self.subtitler.temperature)
+        # Checking if it increased as we predicted
+        self.assertEqual(temp, target_value)
+
+
 
     @patch("tempfile.NamedTemporaryFile")
     def test_upload_audio_wrong_type(self, mock_temp_file):

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -3,17 +3,17 @@ import logging
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
+import tenacity
 from google.genai.errors import ClientError, ServerError
 from pydub import AudioSegment
 from tenacity import RetryCallState
-import tenacity
 
 from subtitle_tool.ai import (
     DEFAULT_WAIT_TIME,
     AIGenerationError,
     AISubtitler,
 )
-from subtitle_tool.subtitles import SubtitleEvent, SubtitleValidationError
+from subtitle_tool.subtitles import SubtitleEvent
 
 # Running tests in DEBUG will help to troubleshoot errors on changes
 logging.getLogger("subtitle_tool").setLevel(logging.DEBUG)
@@ -691,8 +691,6 @@ class TestAISubtitler(unittest.TestCase):
         self.assertGreater(temp, self.subtitler.temperature)
         # Checking if it increased as we predicted
         self.assertEqual(temp, target_value)
-
-
 
     @patch("tempfile.NamedTemporaryFile")
     def test_upload_audio_wrong_type(self, mock_temp_file):

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -10,7 +10,7 @@ from pysubs2 import SSAEvent, SSAFile
 # Assuming the module is imported as subtitle_tool
 from subtitle_tool.subtitles import (
     SubtitleEvent,
-    SubtitleValidationException,
+    SubtitleValidationError,
     equalize_subtitles,
     events_to_subtitles,
     merge_subtitle_events,
@@ -171,7 +171,7 @@ class TestValidateSubtitles(unittest.TestCase):
         ]
         duration = 10.0  # 10 seconds
 
-        with self.assertRaises(SubtitleValidationException) as exc_info:
+        with self.assertRaises(SubtitleValidationError) as exc_info:
             validate_subtitles(subtitles, duration)
 
         self.assertIn("Subtitle ends at 12000", str(exc_info.exception))
@@ -182,7 +182,7 @@ class TestValidateSubtitles(unittest.TestCase):
         subtitles = [SubtitleEvent(start=2000, end=1000, text="Invalid")]  # start > end
         duration = 10.0
 
-        with self.assertRaises(SubtitleValidationException) as exc_info:
+        with self.assertRaises(SubtitleValidationError) as exc_info:
             validate_subtitles(subtitles, duration)
 
         self.assertIn("starts at 2000", str(exc_info.exception))
@@ -196,7 +196,7 @@ class TestValidateSubtitles(unittest.TestCase):
         ]
         duration = 10.0
 
-        with self.assertRaises(SubtitleValidationException) as exc_info:
+        with self.assertRaises(SubtitleValidationError) as exc_info:
             validate_subtitles(subtitles, duration)
 
         self.assertIn("starts at 2000", str(exc_info.exception))
@@ -430,7 +430,7 @@ class TestMergeSubtitleEvents(unittest.TestCase):
         ]
         segment_durations = [10.0]  # Only 10 seconds total
 
-        with self.assertRaises(SubtitleValidationException):
+        with self.assertRaises(SubtitleValidationError):
             merge_subtitle_events(subtitle_groups, segment_durations)
 
     def test_merge_preserves_text_content(self):
@@ -494,7 +494,7 @@ class TestSubtitleValidationException(unittest.TestCase):
     def test_exception_creation(self):
         """Test creating SubtitleValidationException"""
         msg = "Test error message"
-        exc = SubtitleValidationException(msg)
+        exc = SubtitleValidationError(msg)
         self.assertEqual(str(exc), msg)
         self.assertIsInstance(exc, Exception)
 

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "subtitle-tool"
-version = "0.1.28"
+version = "0.1.30"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
The tool utilises a low model temperature to enhance accuracy for both transcription and subtitles. Due to this low temperature, new content generated by the model tends to be similar to previous content, causing excessive retries, often beyond the limit tolerated for incorrect content.

This change brings a slight increase in model temperature each time the generated subtitles are wrong. It hopes to introduce some variation to increase the chance that next subtitle generation will be successful.