### PR TITLE
Prompt tweaks to increase correctness of results

### DIFF
--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -738,7 +738,7 @@ class TestAISubtitler(unittest.TestCase):
             with self.assertRaisesRegex(
                 AIGenerationError, "Parsed response is not a list"
             ):
-                self.subtitler._generate_subtitles(mock_file_ref)
+                self.subtitler._generate_subtitles(0, mock_file_ref)
 
         self.assertEqual(
             self.subtitler.metrics.input_token_count, 10 * expected_retries
@@ -763,7 +763,7 @@ class TestAISubtitler(unittest.TestCase):
         expected_retries = 10
         with patch("time.sleep", lambda _: None):
             with self.assertRaisesRegex(AIGenerationError, "Response is empty"):
-                self.subtitler._generate_subtitles(mock_file_ref)
+                self.subtitler._generate_subtitles(0, mock_file_ref)
 
         self.assertEqual(self.subtitler.metrics.input_token_count, 0)
         self.assertEqual(self.subtitler.metrics.output_token_count, 0)

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "subtitle-tool"
-version = "0.1.41"
+version = "0.1.44"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
After several test batches, I found that Gemini was still unable to produce valid subtitles for some segments. Even with the progressive temperature increase, the results were invalid to the point of extrapolating the retry counter.

This change tweaks the `system prompt` to be more specific around not extrapolating the end of the segment, and the `user prompt` to explicitly add the audio segment length to the model context.