### PR TITLE
Handling None subtitles

### DIFF
--- a/src/subtitle_tool/subtitles.py
+++ b/src/subtitle_tool/subtitles.py
@@ -89,6 +89,9 @@ def validate_subtitles(subtitles: list[SubtitleEvent], duration: float):
         Exception: This method will return an exception if the subtitle is invalid.
     """
 
+    if subtitles is None:
+        raise SubtitleValidationError("Subtitles are None")
+
     # It might as well be that no subtitles are generated for a given segment,
     # when it's only music, for example.
     if len(subtitles) == 0:

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -229,6 +229,16 @@ class TestValidateSubtitles(unittest.TestCase):
         # Should not raise exception
         validate_subtitles(subtitles, duration)
 
+    def test_with_none_subtitle(self):
+        """Test with no subtitle generated"""
+        subtitles = None
+        duration = 10.0
+
+        with self.assertRaises(SubtitleValidationError) as exc_info:
+            validate_subtitles(subtitles, duration)  # type: ignore
+
+        self.assertIn("are None", str(exc_info.exception))
+
 
 class TestSaveToJson(unittest.TestCase):
     """Test save_to_json function"""


### PR DESCRIPTION
When used as a library, the user can pass None to the validation function. This should be deemed as invalid, but it wasn't being handled, so it resulted in a `TypeError` from the `len()` call. This PR covers this case.